### PR TITLE
単語テスト（自習）モード追加

### DIFF
--- a/EnglishSchool.vcxproj
+++ b/EnglishSchool.vcxproj
@@ -148,6 +148,7 @@
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Setting.cpp" />
     <ClCompile Include="Study.cpp" />
+    <ClCompile Include="StudyDrawer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Button.h" />

--- a/EnglishSchool.vcxproj
+++ b/EnglishSchool.vcxproj
@@ -149,6 +149,7 @@
     <ClCompile Include="Setting.cpp" />
     <ClCompile Include="Study.cpp" />
     <ClCompile Include="StudyDrawer.cpp" />
+    <ClCompile Include="Vocabulary.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Button.h" />

--- a/EnglishSchool.vcxproj.filters
+++ b/EnglishSchool.vcxproj.filters
@@ -63,6 +63,9 @@
     <ClCompile Include="GameDrawer.cpp">
       <Filter>ソース ファイル\ui</Filter>
     </ClCompile>
+    <ClCompile Include="StudyDrawer.cpp">
+      <Filter>ソース ファイル\ui</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Define.h">

--- a/EnglishSchool.vcxproj.filters
+++ b/EnglishSchool.vcxproj.filters
@@ -25,14 +25,17 @@
     <Filter Include="ヘッダー ファイル\api">
       <UniqueIdentifier>{2dc168d8-2b7b-4809-8643-7625c0ba5dcd}</UniqueIdentifier>
     </Filter>
-    <Filter Include="ヘッダー ファイル\Domain">
-      <UniqueIdentifier>{788b133d-5bc2-4549-aa46-d8011e910aa6}</UniqueIdentifier>
-    </Filter>
     <Filter Include="ヘッダー ファイル\ui">
       <UniqueIdentifier>{ecd8c1de-947d-46e6-afd2-e51b6fd2c6db}</UniqueIdentifier>
     </Filter>
     <Filter Include="ソース ファイル\ui">
       <UniqueIdentifier>{e49b8fe9-22c1-4623-ade0-02cde5eefde7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ソース ファイル\domain">
+      <UniqueIdentifier>{e829d045-a415-4fdc-b774-e4f4af322322}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ヘッダー ファイル\domain">
+      <UniqueIdentifier>{788b133d-5bc2-4549-aa46-d8011e910aa6}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -65,6 +68,9 @@
     </ClCompile>
     <ClCompile Include="StudyDrawer.cpp">
       <Filter>ソース ファイル\ui</Filter>
+    </ClCompile>
+    <ClCompile Include="Vocabulary.cpp">
+      <Filter>ソース ファイル\domain</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -102,13 +108,13 @@
       <Filter>ヘッダー ファイル\api</Filter>
     </ClInclude>
     <ClInclude Include="Teacher.h">
-      <Filter>ヘッダー ファイル\Domain</Filter>
+      <Filter>ヘッダー ファイル\domain</Filter>
     </ClInclude>
     <ClInclude Include="Vocabulary.h">
-      <Filter>ヘッダー ファイル\Domain</Filter>
+      <Filter>ヘッダー ファイル\domain</Filter>
     </ClInclude>
     <ClInclude Include="Diary.h">
-      <Filter>ヘッダー ファイル\Domain</Filter>
+      <Filter>ヘッダー ファイル\domain</Filter>
     </ClInclude>
     <ClInclude Include="GameDrawer.h">
       <Filter>ヘッダー ファイル\ui</Filter>

--- a/Game.cpp
+++ b/Game.cpp
@@ -14,9 +14,9 @@ Game::Game() {
 	m_font = CreateFontToHandle(NULL, 40, 3);
 	m_selectMode = new SelectMode(m_font);
 	m_lesson = new Lesson();
-	m_study = new Study();
+	m_study = new Study(m_font);
 	m_setting = new Setting();
-	m_backButton = new Button("戻る", 50, 50, 200, 100, GRAY, WHITE, m_font, BLACK);
+	m_backButton = new Button("タイトルへ戻る", 50, 50, 300, 100, GRAY, WHITE, m_font, BLACK);
 }
 
 Game::~Game() {
@@ -41,7 +41,7 @@ void Game::play() {
 		}
 		break;
 	case STUDY_MODE:
-		if (m_study->play()) {
+		if (m_study->play(m_handX, m_handY)) {
 			m_state = SELECT_MODE;
 		}
 		break;
@@ -52,6 +52,7 @@ void Game::play() {
 		break;
 	}
 
+	// タイトルへ戻る
 	if (leftClick() == 1) {
 		if (m_state != GAME_MODE::SELECT_MODE && m_backButton->overlap(m_handX, m_handY)) {
 			m_state = GAME_MODE::SELECT_MODE;

--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -1,16 +1,18 @@
 #include "Define.h"
 #include "Game.h"
 #include "GameDrawer.h"
+#include "StudyDrawer.h"
 
 #include "DxLib.h"
 
 
 GameDrawer::GameDrawer(const Game* game) {
 	m_game_p = game;
+	m_studyDrawer = new StudyDrawer(m_game_p->getStudy());
 }
 
 GameDrawer::~GameDrawer() {
-	
+	delete m_studyDrawer;
 }
 
 void GameDrawer::draw() {
@@ -29,7 +31,7 @@ void GameDrawer::draw() {
 
 		break;
 	case STUDY_MODE:
-
+		m_studyDrawer->draw(handX, handY);
 		break;
 	case SETTING_MODE:
 

--- a/GameDrawer.h
+++ b/GameDrawer.h
@@ -3,12 +3,15 @@
 
 
 class Game;
+class StudyDrawer;
 
 
 class GameDrawer {
 private:
 
 	const Game* m_game_p;
+
+	StudyDrawer* m_studyDrawer;
 
 public:
 

--- a/Study.cpp
+++ b/Study.cpp
@@ -2,6 +2,12 @@
 #include "Control.h"
 #include "Define.h"
 #include "Study.h"
+#include "Vocabulary.h"
+#include "DxLib.h"
+
+#include <sstream>
+
+using namespace std;
 
 
 /*
@@ -40,10 +46,11 @@ bool Study::play(int handX, int handY) {
 	else {
 		if (leftClick() == 1 && m_finishButton->overlap(handX, handY)) {
 			m_state = STUDY_MODE::SELECT_MODE;
+			m_wordTestStudy->init();
 		}
 		switch (m_state) {
 		case WORD_TEST:
-			m_wordTestStudy->play();
+			m_wordTestStudy->play(handX, handY);
 			break;
 		case WORD_ADD:
 			m_wordAddStudy->play();
@@ -64,7 +71,7 @@ void Study::draw(int handX, int handY) const {
 		m_finishButton->draw(handX, handY);
 		switch (m_state) {
 		case WORD_TEST:
-			m_wordTestStudy->draw();
+			m_wordTestStudy->draw(handX, handY);
 			break;
 		case WORD_ADD:
 			m_wordAddStudy->draw();
@@ -78,19 +85,62 @@ void Study::draw(int handX, int handY) const {
 * 単語テスト（自習）
 */
 WordTestStudy::WordTestStudy() {
-
+	m_vocabulary = new Vocabulary("data/vocabulary/vocabulary.csv");
+	m_vocabulary->shuffle();
+	m_font = CreateFontToHandle(NULL, 40, 3);
+	m_answerButton = new Button("正解発表", 100, 750, 200, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
+	m_nextButton = new Button("次へ", 400, 750, 200, 100, BLUE, BLUE, m_font, BLACK);
+	m_importantButton = new Button("要注意", 700, 750, 200, 100, LIGHT_RED, RED, m_font, BLACK);
+	m_removeButton = new Button("削除", 1700, 750, 150, 100, GRAY, WHITE, m_font, BLACK);
+	m_nextButton->changeFlag(false, BLUE);
 }
 
 WordTestStudy::~WordTestStudy() {
-
+	delete m_vocabulary;
+	DeleteFontToHandle(m_font);
 }
 
-bool WordTestStudy::play() {
+bool WordTestStudy::play(int handX, int handY) {
+	if (leftClick() == 1) {
+		if (m_answerButton->overlap(handX, handY)) {
+			m_nextButton->changeFlag(true, LIGHT_BLUE);
+		}
+		if (m_nextButton->overlap(handX, handY)) {
+			m_vocabulary->goNextWord();
+			m_nextButton->changeFlag(false, BLUE);
+		}
+		if (m_importantButton->overlap(handX, handY)) {
+			m_vocabulary->setImportantFlag(!m_vocabulary->getWord().importantFlag);
+		}
+		if (m_removeButton->overlap(handX, handY)) {
+			m_vocabulary->removeWord();
+		}
+	}
 	return false;
 }
 
-void WordTestStudy::draw() {
+void WordTestStudy::init() {
+	m_vocabulary->init();
+	m_vocabulary->shuffle();
+}
 
+void WordTestStudy::draw(int handX, int handY) const {
+	Word word = m_vocabulary->getWord();
+	if (word.importantFlag) {
+		DrawStringToHandle(100, 300, "要注意！！", RED, m_font);
+	}
+	DrawStringToHandle(100, 400, word.english.c_str(), WHITE, m_font);
+	if (m_nextButton->getFlag()) {
+		DrawStringToHandle(100, 500, word.japanese.c_str(), BLUE, m_font);
+	}
+	DrawStringToHandle(150, 600, ("例：" + word.example).c_str(), WHITE, m_font);
+	m_answerButton->draw(handX, handY);
+	m_importantButton->draw(handX, handY);
+	m_nextButton->draw(handX, handY);
+	m_removeButton->draw(handX, handY);
+	ostringstream oss;
+	oss << "総単語数：" << m_vocabulary->getIndex() + 1 << "/" << m_vocabulary->getWordSum() << ", 要注意単語：" << m_vocabulary->getImportantWordSum() << "個";
+	DrawStringToHandle(100, 950, oss.str().c_str(), WHITE, m_font);
 }
 
 
@@ -98,11 +148,11 @@ void WordTestStudy::draw() {
 * 単語追加
 */
 WordAddStudy::WordAddStudy() {
-
+	m_vocabulary = new Vocabulary("data/vocabulary/vocabulary.csv");
 }
 
 WordAddStudy::~WordAddStudy() {
-
+	delete m_vocabulary;
 }
 
 bool WordAddStudy::play() {

--- a/Study.cpp
+++ b/Study.cpp
@@ -1,14 +1,114 @@
+#include "Button.h"
+#include "Control.h"
+#include "Define.h"
 #include "Study.h"
 
 
-Study::Study() {
-
+/*
+* 自習
+*/
+Study::Study(int font) {
+	m_font = font;
+	m_state = STUDY_MODE::SELECT_MODE;
+	m_wordTestStudy = new WordTestStudy();
+	m_wordAddStudy = new WordAddStudy();
+	m_finishButton= new Button("終了", 1650, 50, 200, 100, GRAY, WHITE, m_font, BLACK);
+	m_wordTestButton = new Button("単語テスト", 50, 300, 200, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
+	m_wordAddButton = new Button("単語追加", 300, 300, 200, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
 }
 
 Study::~Study() {
+	delete m_wordTestStudy;
+	delete m_wordAddStudy;
+	delete m_finishButton;
+	delete m_wordTestButton;
+	delete m_wordAddButton;
+}
+
+bool Study::play(int handX, int handY) {
+
+	if (m_state == STUDY_MODE::SELECT_MODE) {
+		if (leftClick() == 1) {
+			if (m_wordTestButton->overlap(handX, handY)) {
+				m_state = STUDY_MODE::WORD_TEST;
+			}
+			else if (m_wordAddButton->overlap(handX, handY)) {
+				m_state = STUDY_MODE::WORD_ADD;
+			}
+		}
+	}
+	else {
+		if (leftClick() == 1 && m_finishButton->overlap(handX, handY)) {
+			m_state = STUDY_MODE::SELECT_MODE;
+		}
+		switch (m_state) {
+		case WORD_TEST:
+			m_wordTestStudy->play();
+			break;
+		case WORD_ADD:
+			m_wordAddStudy->play();
+			break;
+		}
+	}
+
+	return false;
 
 }
 
-bool Study::play() {
+void Study::draw(int handX, int handY) const {
+	if (m_state == STUDY_MODE::SELECT_MODE) {
+		m_wordTestButton->draw(handX, handY);
+		m_wordAddButton->draw(handX, handY);
+	}
+	else {
+		m_finishButton->draw(handX, handY);
+		switch (m_state) {
+		case WORD_TEST:
+			m_wordTestStudy->draw();
+			break;
+		case WORD_ADD:
+			m_wordAddStudy->draw();
+			break;
+		}
+	}
+}
+
+
+/*
+* 単語テスト（自習）
+*/
+WordTestStudy::WordTestStudy() {
+
+}
+
+WordTestStudy::~WordTestStudy() {
+
+}
+
+bool WordTestStudy::play() {
 	return false;
+}
+
+void WordTestStudy::draw() {
+
+}
+
+
+/*
+* 単語追加
+*/
+WordAddStudy::WordAddStudy() {
+
+}
+
+WordAddStudy::~WordAddStudy() {
+
+}
+
+bool WordAddStudy::play() {
+	return false;
+}
+
+void WordAddStudy::draw() {
+
 }

--- a/Study.h
+++ b/Study.h
@@ -1,15 +1,71 @@
 #ifndef STUDY_H_INCLUDED
 #define STUDY_H_INCLUDED
 
+
+class Button;
+class WordTestStudy;
+class WordAddStudy;
+
+
 class Study {
 private:
 
+	enum STUDY_MODE {
+		SELECT_MODE,	// 選択画面
+		WORD_TEST,		// 単語テスト
+		WORD_ADD		// 単語追加
+	};
+
+	STUDY_MODE m_state;
+
+	WordTestStudy* m_wordTestStudy;
+	WordAddStudy* m_wordAddStudy;
+
+	Button* m_finishButton;
+	Button* m_wordTestButton;
+	Button* m_wordAddButton;
+
+	int m_font;
+
 public:
-	Study();
+	Study(int font);
 	~Study();
 
 	// 終了時にtrueを返す
-	bool play();
+	bool play(int handX, int handY);
+
+	void draw(int handX, int handY) const;
 };
+
+
+/*
+* 単語テスト
+*/
+class WordTestStudy {
+private:
+
+public:
+	WordTestStudy();
+	~WordTestStudy();
+
+	bool play();
+	void draw();
+};
+
+
+/*
+* 単語追加
+*/
+class WordAddStudy {
+private:
+
+public:
+	WordAddStudy();
+	~WordAddStudy();
+
+	bool play();
+	void draw();
+};
+
 
 #endif

--- a/Study.h
+++ b/Study.h
@@ -3,6 +3,7 @@
 
 
 class Button;
+class Vocabulary;
 class WordTestStudy;
 class WordAddStudy;
 
@@ -44,12 +45,22 @@ public:
 class WordTestStudy {
 private:
 
+	Vocabulary* m_vocabulary;
+
+	int m_font;
+
+	Button* m_answerButton;
+	Button* m_importantButton;
+	Button* m_nextButton;
+	Button* m_removeButton;
+
 public:
 	WordTestStudy();
 	~WordTestStudy();
 
-	bool play();
-	void draw();
+	bool play(int handX, int handY);
+	void init();
+	void draw(int handX, int handY) const;
 };
 
 
@@ -58,6 +69,8 @@ public:
 */
 class WordAddStudy {
 private:
+
+	Vocabulary* m_vocabulary;
 
 public:
 	WordAddStudy();

--- a/StudyDrawer.cpp
+++ b/StudyDrawer.cpp
@@ -1,0 +1,17 @@
+#include "Study.h"
+#include "StudyDrawer.h"
+
+#include "DxLib.h"
+
+
+StudyDrawer::StudyDrawer(const Study* study) {
+	m_study_p = study;
+}
+
+StudyDrawer::~StudyDrawer() {
+
+}
+
+void StudyDrawer::draw(int handX, int handY) {
+	m_study_p->draw(handX, handY);
+}

--- a/StudyDrawer.h
+++ b/StudyDrawer.h
@@ -1,6 +1,21 @@
 #ifndef STUDY_DRAWER_H_INCLUDED
 #define STUDY_DRAWER_H_INCLUDED
 
+class Study;
 
+
+class StudyDrawer {
+private:
+
+	const Study* m_study_p;
+
+public:
+
+	StudyDrawer(const Study* study);
+	~StudyDrawer();
+
+	void draw(int handX, int handY);
+
+};
 
 #endif

--- a/Vocabulary.cpp
+++ b/Vocabulary.cpp
@@ -1,0 +1,125 @@
+#include "Vocabulary.h"
+#include "DxLib.h"
+
+#include <algorithm>
+
+using namespace std;
+
+
+Vocabulary::Vocabulary(const char* path) {
+	m_path = path;
+	m_index = 0;
+	m_importantWordSum = 0;
+	read();
+}
+
+// ロード
+bool Vocabulary::read() {
+
+	m_words.clear();
+
+	// ファイルポインタ
+	int fp;
+
+	// バッファ
+	const int size = 512;
+	char buff[size];
+
+	// ファイルを開く
+	fp = FileRead_open(m_path.c_str());
+	FileRead_gets(buff, size, fp); // 最初の一行目はカラム名なので捨てる
+
+	// ファイルの終端までループ
+	while (FileRead_eof(fp) == 0) {
+		// いったんバッファに一行分のテキストを入れる
+		FileRead_gets(buff, size, fp);
+		Word word;
+		int now = 0;
+		string oneCell = "";
+		// 1文字ずつ見ていく
+		for (int i = 0; buff[i] != '\0'; i++) {
+			// CSVファイルなのでカンマで区切ってoneDataにpush_back
+			if (buff[i] == ',' && now < 3) {
+				if (now == 0) {
+					word.importantFlag = (bool)stoi(oneCell);
+					if (word.importantFlag) { m_importantWordSum++; }
+				}
+				else if (now == 1) {
+					word.english = oneCell;
+				}
+				else if (now == 2) {
+					word.japanese = oneCell;
+				}
+				now++;
+				oneCell = "";
+			}
+			else { // カンマ以外の文字なら合体
+				oneCell += buff[i];
+			}
+		}
+		// 4つめは例文
+		word.example = oneCell;
+		m_words.push_back(word);
+	}
+
+	// ファイルを閉じる
+	FileRead_close(fp);
+	return true;
+
+}
+
+// セーブ
+bool Vocabulary::write() const {
+	return true;
+}
+
+// 単語追加
+void Vocabulary::addWord(Word word) {
+	if (word.importantFlag) { m_importantWordSum++; }
+	m_words.push_back(word);
+}
+
+// 単語除去
+void Vocabulary::removeWord() {
+	if ((int)m_words.size() == 1) { return; }
+	if (m_words[m_index].importantFlag) { m_importantWordSum--; }
+	m_words[m_index] = m_words.back();
+	m_words.pop_back();
+	if (m_index >= (int)m_words.size()) { m_index = (int)m_words.size() - 1; }
+}
+
+// 要注意
+void Vocabulary::setImportantFlag(bool flag) {
+	if (!m_words[m_index].importantFlag && flag) { m_importantWordSum++; }
+	else if (m_words[m_index].importantFlag && !flag) { m_importantWordSum--; }
+	m_words[m_index].importantFlag = flag;
+}
+
+// 単語シャッフル
+void Vocabulary::shuffle() {
+	int size = (int)m_words.size();
+	for (int i = 0; i < size; i++) {
+		int r = GetRand(size - 1 - i) + i;
+		Word tmp = m_words[i];
+		m_words[i] = m_words[r];
+		m_words[r] = tmp;
+	}
+}
+
+// 次の単語取得
+Word Vocabulary::getWord() {
+	return m_words[m_index];
+}
+
+// 次の単語へ移動
+void Vocabulary::goNextWord() {
+	if (++m_index == (int)m_words.size()) {
+		m_index = 0;
+	}
+}
+
+void Vocabulary::init() {
+	m_index = 0;
+	m_importantWordSum = 0;
+	read();
+}

--- a/Vocabulary.h
+++ b/Vocabulary.h
@@ -1,6 +1,51 @@
 #ifndef VOCABULARY_H_INCLUDED
 #define VOCABULARY_H_INCLUDED
 
+#include <string>
+#include <vector>
 
+struct Word {
+	std::string english;	// 英単語
+	std::string japanese;	// 単語の日本語訳
+	std::string example;	// 英語の例文
+	bool importantFlag;		// 要注意単語ならtrue
+};
+
+class Vocabulary {
+private:
+
+	std::string m_path;
+
+	std::vector<Word> m_words;
+
+	int m_index;
+
+	int m_importantWordSum;
+
+public:
+
+	Vocabulary(const char* path);
+
+	// ゲッタ
+	inline int getIndex() const { return m_index; }
+	inline int getWordSum() const { return (int)m_words.size(); }
+	inline int getImportantWordSum() const { return m_importantWordSum; }
+
+	// ファイルの読み書き
+	bool read();
+	bool write() const;
+
+	// 単語追加用
+	void addWord(Word word);
+	void removeWord();
+	void setImportantFlag(bool flag);
+
+	// 単語テスト用
+	void shuffle();
+	Word getWord();
+	void goNextWord();
+	void init();
+
+};
 
 #endif


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り。

csvファイルを単語帳とする。

Vocabularyクラスがcsvファイルを読み込む。

単語テスト時は単語帳をシャッフルし、順に表示する。

「正解発表」を押すと日本語訳が出て次の単語へ進めるようになる。

「要注意」を押すと要注意単語としてマークできる。（逆に外すことも可能）

「削除」を押すとその単語を単語帳から削除する。謝って押すのを防ぐため端っこに少し小さめにボタンを表示

「タイトルへ戻る」を押すと自習モードの進行状況はそのままにタイトルへ戻る。

単語テスト中に「終了」を押すと単語テストの進行状況は破棄され自習のモード選択画面へ戻る。

# やったこと
記入欄

# 懸念点
記入欄