### PR TITLE
重要語のみテストするモード実装

### DIFF
--- a/Study.h
+++ b/Study.h
@@ -13,19 +13,18 @@ class Study {
 private:
 
 	enum STUDY_MODE {
-		SELECT_MODE,	// 選択画面
-		WORD_TEST,		// 単語テスト
-		WORD_ADD		// 単語追加
+		SELECT_MODE,			// 選択画面
+		WORD_TEST,				// 単語テスト
+		WORD_TEST_IMPORTANT		// 単語追加
 	};
 
 	STUDY_MODE m_state;
 
 	WordTestStudy* m_wordTestStudy;
-	WordAddStudy* m_wordAddStudy;
 
 	Button* m_finishButton;
 	Button* m_wordTestButton;
-	Button* m_wordAddButton;
+	Button* m_onlyImportantTestButton;
 
 	int m_font;
 
@@ -63,26 +62,9 @@ public:
 	WordTestStudy(Teacher* teacher_p);
 	~WordTestStudy();
 
-	bool play(int handX, int handY);
-	void init();
+	bool play(int handX, int handY, bool onlyImportant);
+	void init(bool onlyImportant);
 	void draw(int handX, int handY) const;
-};
-
-
-/*
-* 単語追加
-*/
-class WordAddStudy {
-private:
-
-	Vocabulary* m_vocabulary;
-
-public:
-	WordAddStudy();
-	~WordAddStudy();
-
-	bool play();
-	void draw();
 };
 
 

--- a/Vocabulary.cpp
+++ b/Vocabulary.cpp
@@ -122,9 +122,13 @@ Word Vocabulary::getWord() {
 }
 
 // ŽŸ‚Ì’PŒê‚ÖˆÚ“®
-void Vocabulary::goNextWord() {
-	if (++m_index == (int)m_words.size()) {
-		m_index = 0;
+void Vocabulary::goNextWord(bool onlyImportant) {
+	unsigned int i = 0;
+	while (i == 0 || (onlyImportant && !m_words[m_index].importantFlag && i < m_words.size())) {
+		if (++m_index == (int)m_words.size()) {
+			m_index = 0;
+		}
+		i++;
 	}
 }
 
@@ -132,4 +136,10 @@ void Vocabulary::init() {
 	m_index = 0;
 	m_importantWordSum = 0;
 	read();
+}
+
+void Vocabulary::setFirstImportantWord() {
+	if (!m_words[m_index].importantFlag) {
+		goNextWord(true);
+	}
 }

--- a/Vocabulary.h
+++ b/Vocabulary.h
@@ -43,8 +43,9 @@ public:
 	// 単語テスト用
 	void shuffle();
 	Word getWord();
-	void goNextWord();
+	void goNextWord(bool onlyImportant);
 	void init();
+	void setFirstImportantWord();
 
 };
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り

# やったこと
重要好みテストするモードは基本的に単語テストモードと同じだが、次の単語がimportantFlag==falseならスキップする。

また、単語追加モードは実装しない予定になったのでボタンなど削除した。

# 懸念点
記入欄