### PR TITLE
教師カスタマイズ機能を追加

### DIFF
--- a/EnglishSchool.vcxproj
+++ b/EnglishSchool.vcxproj
@@ -148,6 +148,7 @@
     <ClCompile Include="LessonDrawer.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Setting.cpp" />
+    <ClCompile Include="SettingDrawer.cpp" />
     <ClCompile Include="Study.cpp" />
     <ClCompile Include="StudyDrawer.cpp" />
     <ClCompile Include="Teacher.cpp" />

--- a/EnglishSchool.vcxproj.filters
+++ b/EnglishSchool.vcxproj.filters
@@ -72,17 +72,20 @@
     <ClCompile Include="Vocabulary.cpp">
       <Filter>ソース ファイル\domain</Filter>
     </ClCompile>
-    <ClCompile Include="Teacher.cpp">
-      <Filter>ソース ファイル</Filter>
-    </ClCompile>
-    <ClCompile Include="TeacherDrawer.cpp">
-      <Filter>ソース ファイル</Filter>
-    </ClCompile>
     <ClCompile Include="Timer.cpp">
       <Filter>ソース ファイル\tools</Filter>
     </ClCompile>
     <ClCompile Include="LessonDrawer.cpp">
       <Filter>ソース ファイル\ui</Filter>
+    </ClCompile>
+    <ClCompile Include="SettingDrawer.cpp">
+      <Filter>ソース ファイル\ui</Filter>
+    </ClCompile>
+    <ClCompile Include="TeacherDrawer.cpp">
+      <Filter>ソース ファイル\ui</Filter>
+    </ClCompile>
+    <ClCompile Include="Teacher.cpp">
+      <Filter>ソース ファイル\domain</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Game.cpp
+++ b/Game.cpp
@@ -33,7 +33,7 @@ Game::Game() {
 	m_dailyStats = new Stats(m_dateStr.c_str());
 
 	// 教師
-	m_teacher = new Teacher("トモチ");
+	m_teacher = new Teacher(0, 0);
 	m_teacher->setRandomText();
 
 	m_handX = 0;
@@ -43,7 +43,7 @@ Game::Game() {
 	m_selectMode = new SelectMode(m_font);
 	m_lesson = new Lesson(m_font, m_teacher, m_stats, m_dailyStats);
 	m_study = new Study(m_font, m_teacher);
-	m_setting = new Setting();
+	m_setting = new Setting(m_font, m_teacher);
 	m_backButton = new Button("タイトルへ戻る", 50, 50, 300, 100, GRAY, WHITE, m_font, BLACK);
 	m_stopWatch = new StopWatch();
 }
@@ -60,6 +60,7 @@ Game::~Game() {
 	delete m_stopWatch;
 	delete m_stats;
 	delete m_dailyStats;
+	delete m_backButton;
 }
 
 void Game::play() {
@@ -85,7 +86,7 @@ void Game::play() {
 		}
 		break;
 	case SETTING_MODE:
-		if (m_setting->play()) {
+		if (m_setting->play(m_handX, m_handY)) {
 			m_state = GAME_MODE::SELECT_MODE;
 		}
 		break;

--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -3,6 +3,7 @@
 #include "Game.h"
 #include "GameDrawer.h"
 #include "LessonDrawer.h"
+#include "SettingDrawer.h"
 #include "StudyDrawer.h"
 #include "TeacherDrawer.h"
 
@@ -15,17 +16,21 @@ GameDrawer::GameDrawer(const Game* game) {
 	m_studyDrawer = new StudyDrawer(m_game_p->getStudy());
 	m_lessonDrawer = new LessonDrawer(m_game_p->getLesson());
 	m_teacherDrawer = new TeacherDrawer(m_game_p->getTeacher());
+	m_settingDrawer = new SettingDrawer(m_game_p->getSetting());
 	m_kokuban = LoadGraph("picture/kokuban.png");
 }
 
 GameDrawer::~GameDrawer() {
 	delete m_studyDrawer;
+	delete m_lessonDrawer;
+	delete m_teacherDrawer;
+	delete m_settingDrawer;
 	DeleteGraph(m_kokuban);
 }
 
 void GameDrawer::draw() {
 
-	if (controlLeftShift() == 1 || controlRightShift() == 1) {
+	if ((controlLeftShift() > 0 || controlRightShift() > 0) && rightClick() == 1) {
 		m_dispTeacher = !m_dispTeacher;
 	}
 
@@ -56,7 +61,7 @@ void GameDrawer::draw() {
 		m_studyDrawer->draw(handX, handY);
 		break;
 	case SETTING_MODE:
-
+		m_settingDrawer->draw(handX, handY);
 		break;
 	}
 

--- a/GameDrawer.h
+++ b/GameDrawer.h
@@ -4,6 +4,7 @@
 
 class Game;
 class LessonDrawer;
+class SettingDrawer;
 class StudyDrawer;
 class TeacherDrawer;
 
@@ -18,6 +19,8 @@ private:
 	StudyDrawer* m_studyDrawer;
 
 	LessonDrawer* m_lessonDrawer;
+
+	SettingDrawer* m_settingDrawer;
 
 	// •”Â‰æ‘œ
 	int m_kokuban;

--- a/Setting.cpp
+++ b/Setting.cpp
@@ -1,14 +1,37 @@
 #include "Setting.h"
+#include "Button.h"
+#include "Control.h"
+#include "Define.h"
+#include "Teacher.h"
 
 
-Setting::Setting() {
-
+Setting::Setting(int font, Teacher* teacher_p) {
+	m_font = font;
+	m_teacher_p = teacher_p;
+	m_changeTeacherButton = new Button("‹³t•ÏX", 100, 300, 400, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
+	m_changeClothButton = new Button("•‘••ÏX", 100, 450, 400, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
 }
 
 Setting::~Setting() {
-
+	delete m_changeTeacherButton;
+	delete m_changeClothButton;
 }
 
-bool Setting::play() {
+bool Setting::play(int handX, int handY) {
+	if (leftClick() == 1) {
+		if (m_changeTeacherButton->overlap(handX, handY)) {
+			m_teacher_p->setNextTeacher();
+			m_teacher_p->setText(5, 120, EMOTE::NORMAL, true);
+		}
+		if (m_changeClothButton->overlap(handX, handY)) {
+			m_teacher_p->setNextCloth();
+			m_teacher_p->setText(6, 120, EMOTE::NORMAL, true);
+		}
+	}
 	return false;
+}
+
+void Setting::draw(int handX, int handY) const {
+	m_changeTeacherButton->draw(handX, handY);
+	m_changeClothButton->draw(handX, handY);
 }

--- a/Setting.h
+++ b/Setting.h
@@ -1,15 +1,26 @@
 #ifndef SETTING_H_INCLUDED
 #define SETTING_H_INCLUDED
 
+class Button;
+class Teacher;
+
 class Setting {
 private:
 
+	int m_font;
+
+	Teacher* m_teacher_p;
+
+	Button* m_changeTeacherButton;
+	Button* m_changeClothButton;
+
 public:
-	Setting();
+	Setting(int font, Teacher* teacher_p);
 	~Setting();
 
 	// I—¹‚Étrue‚ğ•Ô‚·
-	bool play();
+	bool play(int handX, int handY);
+	void draw(int handX, int handY) const;
 };
 
 #endif

--- a/SettingDrawer.cpp
+++ b/SettingDrawer.cpp
@@ -1,0 +1,12 @@
+#include "SettingDrawer.h"
+#include "Setting.h"
+#include "Teacher.h"
+
+
+SettingDrawer::SettingDrawer(const Setting* setting) {
+	m_setting = setting;
+}
+
+void SettingDrawer::draw(int handX, int handY) {
+	m_setting->draw(handX, handY);
+}

--- a/SettingDrawer.h
+++ b/SettingDrawer.h
@@ -1,6 +1,18 @@
 #ifndef SETTING_DRAWER_H_INCLUDED
 #define SETTING_DRAWER_H_INCLUDED
 
+class Setting;
+class Teacher;
 
+class SettingDrawer {
+private:
+
+	const Setting* m_setting;
+
+public:
+	SettingDrawer(const Setting* setting);
+
+	void draw(int handX, int handY);
+};
 
 #endif

--- a/Teacher.cpp
+++ b/Teacher.cpp
@@ -15,6 +15,14 @@ int calcIndex(int size, int index, bool repeat) {
 }
 
 
+void clearVector(vector<int>& vec) {
+	for (unsigned int i = 0; i < vec.size(); i++) {
+		DeleteGraph(vec[i]);
+	}
+	vec.clear();
+}
+
+
 
 /*
 * 教師のアクション
@@ -172,20 +180,15 @@ std::string Text::getText() const {
 /*
 * 教師
 */
-Teacher::Teacher(const char* name) {
-	// 名前
-	m_name = name;
+Teacher::Teacher(int nameIndex, int clothIndex) {
+	m_reverseX = true;
 
-	// 画像
-	string path = "picture/";
-	path += m_name;
-	path += "/";
-	m_normalHandle.push_back(LoadGraph((path + "通常1.png").c_str()));
-	m_normalHandle.push_back(LoadGraph((path + "通常2.png").c_str()));
-	m_smileHandle.push_back(LoadGraph((path + "笑顔1.png").c_str()));
-	m_smileHandle.push_back(LoadGraph((path + "笑顔2.png").c_str()));
-	m_angryHandle.push_back(LoadGraph((path + "注意1.png").c_str()));
-	m_angryHandle.push_back(LoadGraph((path + "注意2.png").c_str()));
+	// 名前
+	m_name = NAME_LIST[nameIndex];
+
+	m_cloth = CLOTH_LIST[clothIndex];
+
+	changeTeacher(nameIndex);
 
 	// セリフ
 	m_text = nullptr;
@@ -272,4 +275,57 @@ void Teacher::jump() {
 
 void Teacher::quake() {
 	m_teacherAction->setQuakeCnt(30);
+}
+
+void Teacher::setNextTeacher() {
+	changeTeacher(m_nameIndex + 1);
+}
+
+void Teacher::setNextCloth() {
+	changeCloth(m_clothIndex + 1);
+}
+
+// 教師変更
+void Teacher::changeTeacher(int index) {
+
+	m_nameIndex = index % NAME_SUM;
+	if (m_nameIndex == 2) {
+		m_reverseX = false;
+	}
+	else {
+		m_reverseX = true;
+	}
+
+	// セリフがあるなら消す
+	if (m_text != nullptr) { 
+		delete m_text;
+		m_text = nullptr;
+	}
+
+	// 名前
+	m_name = NAME_LIST[m_nameIndex];
+
+	// 初期化
+	clearVector(m_normalHandle);
+	clearVector(m_smileHandle);
+	clearVector(m_angryHandle);
+
+	// 画像
+	string path = "picture/";
+	path += m_name;
+	path += "/";
+	path += m_cloth;
+	m_normalHandle.push_back(LoadGraph((path + "通常1.png").c_str()));
+	m_normalHandle.push_back(LoadGraph((path + "通常2.png").c_str()));
+	m_smileHandle.push_back(LoadGraph((path + "笑顔1.png").c_str()));
+	m_smileHandle.push_back(LoadGraph((path + "笑顔2.png").c_str()));
+	m_angryHandle.push_back(LoadGraph((path + "注意1.png").c_str()));
+	m_angryHandle.push_back(LoadGraph((path + "注意2.png").c_str()));
+}
+
+// 服装変更
+void Teacher::changeCloth(int index) {
+	m_clothIndex = index % CLOTH_SUM;
+	m_cloth = CLOTH_LIST[m_clothIndex];
+	changeTeacher(m_nameIndex);
 }

--- a/Teacher.h
+++ b/Teacher.h
@@ -103,6 +103,20 @@ enum EMOTE {
 	ANGRY	// 注意
 };
 
+static const int NAME_SUM = 3;
+static const char* NAME_LIST[NAME_SUM] = {
+	"トモチ",
+	"ミヤトネ",
+	"オワダ"
+};
+
+static const int CLOTH_SUM = 3;
+static const char* CLOTH_LIST[CLOTH_SUM] = {
+	"",
+	"水着",
+	"突撃"
+};
+
 /*
 * 教師
 */
@@ -120,6 +134,15 @@ private:
 	// 名前
 	const char* m_name;
 
+	// 服
+	const char* m_cloth;
+
+	int m_nameIndex;
+	int m_clothIndex;
+
+	// キャラを反転描画するか
+	bool m_reverseX;
+
 	// セリフ
 	Text* m_text;
 
@@ -132,12 +155,13 @@ private:
 
 public:
 
-	Teacher(const char* name);
+	Teacher(int nameIndex, int clothIndex);
 	~Teacher();
 
 	// ゲッタ
 	inline const Text* getText() const { return m_text; }
 	inline const TeacherAction* getAction() const { return m_teacherAction; }
+	inline bool getReverseX() const { return m_reverseX; }
 
 	// 画像取得
 	int getHandle() const;
@@ -156,6 +180,16 @@ public:
 	void jump();
 
 	void quake();
+
+	void setNextTeacher();
+
+	void setNextCloth();
+
+	// 教師変更
+	void changeTeacher(int index);
+
+	// 服装変更
+	void changeCloth(int index);
 
 };
 

--- a/TeacherDrawer.cpp
+++ b/TeacherDrawer.cpp
@@ -33,7 +33,7 @@ void TeacherDrawer::draw() {
 	int dx = 0, dy = 0;
 	dx = m_teacher->getAction()->getDx();
 	dy = m_teacher->getAction()->getDy();
-	DrawRotaGraph(1500 + dx, 600 + dy, 0.7, 0, handle, TRUE, TRUE);
+	DrawRotaGraph(1500 + dx, 600 + dy, 0.7, 0, handle, TRUE, m_teacher->getReverseX());
 
 }
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り

タイトルから設定画面へ行き、ボタンを押すと教師の変更・服装の変更ができる。

# やったこと
Settingクラスの中身を実装

# 懸念点
レベルを上げないと選べない教師・服装を用意する仕様はまだない