### PR TITLE
教師のレベルアップ機能追加

### DIFF
--- a/Lesson.cpp
+++ b/Lesson.cpp
@@ -163,6 +163,7 @@ bool Lesson::play(int handX, int handY) {
 			m_state = LESSON_NAME::SELECT_LESSON;
 			m_wordTestStudy->init(false);
 		}
+		m_teacher_p->addExp(1);
 	}
 	return false;
 }

--- a/Main.cpp
+++ b/Main.cpp
@@ -83,8 +83,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 		}
 		Wait();
 		if (controlEsc() == TRUE) { 
-			delete game;
-			DxLib_End();
+			break;
 		}
 		//FPSëÄçÏÇ±Ç±Ç‹Ç≈
 	}

--- a/Study.cpp
+++ b/Study.cpp
@@ -46,6 +46,7 @@ bool Study::play(int handX, int handY) {
 		}
 	}
 	else {
+		m_teacher_p->addExp(1);
 		if (leftClick() == 1 && m_finishButton->overlap(handX, handY)) {
 			m_state = STUDY_MODE::SELECT_MODE;
 			m_wordTestStudy->init(false);

--- a/Teacher.cpp
+++ b/Teacher.cpp
@@ -184,11 +184,27 @@ Teacher::Teacher(int nameIndex, int clothIndex) {
 	m_reverseX = true;
 
 	// 名前
-	m_name = NAME_LIST[nameIndex];
+	m_name = TEACHER_LIST[nameIndex];
 
 	m_cloth = CLOTH_LIST[clothIndex];
 
 	changeTeacher(nameIndex);
+
+	for (unsigned int i = 0; i < TEACHER_SUM; i++) {
+		m_exp.push_back(0);
+		string path = "data/teacher/";
+		path += TEACHER_LIST[i];
+		path += ".dat";
+		FILE* intFp = nullptr;
+		if (fopen_s(&intFp, path.c_str(), "rb") != 0) {
+			continue;
+		}
+		// Read
+		long long int exp = 0;
+		fread(&exp, sizeof(exp), 1, intFp);
+		m_exp[i] = exp;
+		fclose(intFp);
+	}
 
 	// セリフ
 	m_text = nullptr;
@@ -204,6 +220,19 @@ Teacher::Teacher(int nameIndex, int clothIndex) {
 }
 
 Teacher::~Teacher() {
+	for (unsigned int i = 0; i < TEACHER_SUM; i++) {
+		string path = "data/teacher/";
+		path += TEACHER_LIST[i];
+		path += ".dat";
+		FILE* intFp = nullptr;
+		if (fopen_s(&intFp, path.c_str(), "wb") != 0) {
+			continue;
+		}
+		// Read
+		long long int exp = m_exp[i];
+		fwrite(&exp, sizeof(exp), 1, intFp);
+		fclose(intFp);
+	}
 	for (unsigned int i = 0; i < m_normalHandle.size(); i++) {
 		DeleteGraph(m_normalHandle[i]);
 	}
@@ -288,7 +317,7 @@ void Teacher::setNextCloth() {
 // 教師変更
 void Teacher::changeTeacher(int index) {
 
-	m_nameIndex = index % NAME_SUM;
+	m_nameIndex = index % TEACHER_SUM;
 	if (m_nameIndex == 2 || m_nameIndex == 3) {
 		m_reverseX = false;
 	}
@@ -303,7 +332,7 @@ void Teacher::changeTeacher(int index) {
 	}
 
 	// 名前
-	m_name = NAME_LIST[m_nameIndex];
+	m_name = TEACHER_LIST[m_nameIndex];
 
 	// 初期化
 	clearVector(m_normalHandle);

--- a/Teacher.h
+++ b/Teacher.h
@@ -103,8 +103,8 @@ enum EMOTE {
 	ANGRY	// 注意
 };
 
-static const int NAME_SUM = 5;
-static const char* NAME_LIST[NAME_SUM] = {
+static const int TEACHER_SUM = 5;
+static const char* TEACHER_LIST[TEACHER_SUM] = {
 	"トモチ",
 	"ミヤトネ",
 	"オワダ",
@@ -155,6 +155,9 @@ private:
 
 	TeacherAction* m_teacherAction;
 
+	// 経験値
+	std::vector<long long int> m_exp;
+
 public:
 
 	Teacher(int nameIndex, int clothIndex);
@@ -164,6 +167,8 @@ public:
 	inline const Text* getText() const { return m_text; }
 	inline const TeacherAction* getAction() const { return m_teacherAction; }
 	inline bool getReverseX() const { return m_reverseX; }
+	inline long long int getExp() const { return m_exp[m_nameIndex]; }
+	inline long long int getLevel() const { return m_exp[m_nameIndex] / 60 / 60 / 60 / 10; }
 
 	// 画像取得
 	int getHandle() const;
@@ -192,6 +197,9 @@ public:
 
 	// 服装変更
 	void changeCloth(int index);
+
+	// 経験値獲得
+	void addExp(long long int exp) { m_exp[m_nameIndex] += exp; }
 
 };
 

--- a/TeacherDrawer.cpp
+++ b/TeacherDrawer.cpp
@@ -1,9 +1,11 @@
 #include "TeacherDrawer.h"
 #include "Teacher.h"
+#include "Timer.h"
 #include "Define.h"
 #include "DxLib.h"
 
 #include <algorithm>
+#include <sstream>
 
 using namespace std;
 
@@ -35,6 +37,11 @@ void TeacherDrawer::draw() {
 	dy = m_teacher->getAction()->getDy();
 	DrawRotaGraph(1500 + dx, 600 + dy, 0.7, 0, handle, TRUE, m_teacher->getReverseX());
 
+	// ‹³Žt‚ÌƒŒƒxƒ‹
+	ostringstream oss;
+	oss << "Level: " << m_teacher->getLevel();
+	DrawStringToHandle(900, 990, oss.str().c_str(), BLACK, m_font);
+	DrawStringToHandle(900, 1040, getTimeString(m_teacher->getExp()).c_str(), BLACK, m_font);
 }
 
 void TeacherDrawer::drawText(int x, int y, int height, const std::string text, int color, int font) {


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り

# やったこと
Teacherで各教師の経験値を持たせる。

セーブファイルは教師ごとに分ける。（今後経験値以外もセーブ対象に増えるかもしれず、そのときセーブデータを移行しやすくするため）

# 懸念点
記入欄