### PR TITLE
レベルによってセリフや服装が増える機能追加

### DIFF
--- a/Teacher.cpp
+++ b/Teacher.cpp
@@ -188,8 +188,6 @@ Teacher::Teacher(int nameIndex, int clothIndex) {
 
 	m_cloth = CLOTH_LIST[clothIndex];
 
-	changeTeacher(nameIndex);
-
 	for (unsigned int i = 0; i < TEACHER_SUM; i++) {
 		m_exp.push_back(0);
 		string path = "data/teacher/";
@@ -217,6 +215,8 @@ Teacher::Teacher(int nameIndex, int clothIndex) {
 	m_animeRepeat = true;
 
 	m_handleIndex = 0;
+
+	changeTeacher(nameIndex);
 }
 
 Teacher::~Teacher() {
@@ -265,13 +265,27 @@ void Teacher::setText(int num, int wait, EMOTE emote, bool animeRepeat) {
 	m_animeRepeat = animeRepeat;
 }
 
+// 
 void Teacher::setRandomText() {
-	int num = GetRand(4) + 1000;
+	// セリフの総数
+	int sum = 5;
+	// レベルが上がるとセリフの数が増える
+	if (getLevel() < 10) {
+		sum = 5;
+	}
+	int num = GetRand(sum - 1) + 1000;
 	setText(num, 120, EMOTE::NORMAL, true);
 }
 
+// 
 void Teacher::setAdviceText() {
-	int num = GetRand(4) + 2000;
+	// セリフの総数
+	int sum = 5;
+	// レベルが上がるとセリフの数が増える
+	if (getLevel() < 10) {
+		sum = 5;
+	}
+	int num = GetRand(sum - 1) + 2000;
 	setText(num, 120, EMOTE::NORMAL, true);
 }
 
@@ -333,6 +347,12 @@ void Teacher::changeTeacher(int index) {
 
 	// 名前
 	m_name = TEACHER_LIST[m_nameIndex];
+
+	// レベルと使える服の判定
+	if (getLevel() / 10 < m_clothIndex) {
+		m_clothIndex = 0;
+		m_cloth = CLOTH_LIST[m_clothIndex];
+	}
 
 	// 初期化
 	clearVector(m_normalHandle);

--- a/Teacher.h
+++ b/Teacher.h
@@ -103,6 +103,7 @@ enum EMOTE {
 	ANGRY	// 注意
 };
 
+// 教師一覧
 static const int TEACHER_SUM = 5;
 static const char* TEACHER_LIST[TEACHER_SUM] = {
 	"トモチ",
@@ -112,6 +113,7 @@ static const char* TEACHER_LIST[TEACHER_SUM] = {
 	"タキノ"
 };
 
+// 服 10レベルごとに使える服が+1されていく
 static const int CLOTH_SUM = 3;
 static const char* CLOTH_LIST[CLOTH_SUM] = {
 	"",
@@ -168,7 +170,8 @@ public:
 	inline const TeacherAction* getAction() const { return m_teacherAction; }
 	inline bool getReverseX() const { return m_reverseX; }
 	inline long long int getExp() const { return m_exp[m_nameIndex]; }
-	inline long long int getLevel() const { return m_exp[m_nameIndex] / 60 / 60 / 60 / 10; }
+	// Level = exp / 60 / 60 / 60 / 10
+	inline long long int getLevel() const { return m_exp[m_nameIndex] / 2160000; }
 
 	// 画像取得
 	int getHandle() const;
@@ -199,7 +202,14 @@ public:
 	void changeCloth(int index);
 
 	// 経験値獲得
-	void addExp(long long int exp) { m_exp[m_nameIndex] += exp; }
+	void addExp(long long int exp) { 
+		long long int prevLevel = getLevel();
+		m_exp[m_nameIndex] += exp;
+		// レベルアップ
+		if(prevLevel < getLevel()){
+			setText(7, 120, EMOTE::SMILE, true);
+		}
+	}
 
 };
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り

10レベルごとに服装が1つ増える。現状2つまで増える

セリフも同様だが、まだセリフを作っていない。

また、レベルアップ時に教師がジャンプしてしゃべるようにした。

# やったこと
記入欄

# 懸念点
記入欄