### PR TITLE
レベルアップで発言が増える&data更新の仕様変更

### DIFF
--- a/Lesson.cpp
+++ b/Lesson.cpp
@@ -164,10 +164,11 @@ bool Lesson::play(int handX, int handY) {
 			break;
 	}
 	if (m_state != LESSON_NAME::SELECT_LESSON) {
+		// ƒŒƒbƒXƒ“I—¹
 		if (leftClick() == 1 && m_finishButton->overlap(handX, handY)) {
 			m_state = LESSON_NAME::SELECT_LESSON;
-			m_wordTestStudy->init(false);
-			m_speakingPractice->init(false);
+			m_wordTestStudy->end();
+			m_speakingPractice->end();
 		}
 		m_teacher_p->addExp(1);
 	}

--- a/Lesson.cpp
+++ b/Lesson.cpp
@@ -253,7 +253,9 @@ void Lesson::draw(int handX, int handY) const {
 		break;
 	}
 	DrawStringToHandle(100, 250, lessonName.c_str(), WHITE, m_font);
-	if (m_state != LESSON_NAME::SELECT_LESSON && m_state != LESSON_NAME::WORD_TEST && m_state != LESSON_NAME::WORD_TEST_IMPORTANT) {
+	if (m_state != LESSON_NAME::SELECT_LESSON
+		&& m_state != LESSON_NAME::WORD_TEST && m_state != LESSON_NAME::WORD_TEST_IMPORTANT
+		&& m_state != LESSON_NAME::SPEAKING_STUDY) {
 		DrawStringToHandle(550, 550, getTimeString(m_stopWatch->getCnt()).c_str(), WHITE, m_font);
 	}
 }

--- a/Study.cpp
+++ b/Study.cpp
@@ -62,7 +62,8 @@ bool Study::play(int handX, int handY) {
 		m_teacher_p->addExp(1);
 		if (leftClick() == 1 && m_finishButton->overlap(handX, handY)) {
 			m_state = STUDY_MODE::SELECT_MODE;
-			m_wordTestStudy->init(false);
+			m_wordTestStudy->end();
+			m_speakingPractiace->end();
 		}
 		switch (m_state) {
 		case WORD_TEST:
@@ -112,8 +113,7 @@ void Study::draw(int handX, int handY) const {
 */
 WordTestStudy::WordTestStudy(Teacher* teacher_p) {
 	m_teacher_p = teacher_p;
-	m_vocabulary = new Vocabulary("data/vocabulary/vocabulary.csv");
-	m_vocabulary->shuffle();
+	m_vocabulary = nullptr;
 	m_font = CreateFontToHandle(NULL, 40, 3);
 	m_answerButton = new Button("³‰ð”­•\", 100, 750, 200, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
 	m_nextButton = new Button("ŽŸ‚Ö", 400, 750, 200, 100, BLUE, BLUE, m_font, BLACK);
@@ -124,8 +124,10 @@ WordTestStudy::WordTestStudy(Teacher* teacher_p) {
 }
 
 WordTestStudy::~WordTestStudy() {
-	m_vocabulary->write();
-	delete m_vocabulary;
+	if (m_vocabulary != nullptr) {
+		m_vocabulary->write();
+		delete m_vocabulary;
+	}
 	DeleteFontToHandle(m_font);
 	delete m_answerButton;
 	delete m_nextButton;
@@ -160,13 +162,24 @@ bool WordTestStudy::play(int handX, int handY, bool onlyImportant) {
 
 void WordTestStudy::init(bool onlyImportant) {
 	m_nextButton->changeFlag(false, BLUE);
-	m_vocabulary->write();
+	if (m_vocabulary != nullptr) {
+		end();
+	}
+	m_vocabulary = new Vocabulary("data/vocabulary/vocabulary.csv");
 	m_vocabulary->init();
 	m_vocabulary->shuffle();
 	if (onlyImportant) {
 		m_vocabulary->setFirstImportantWord();
 	}
 	m_stopWatch->init();
+}
+
+void WordTestStudy::end() {
+	if (m_vocabulary != nullptr) {
+		m_vocabulary->write();
+		delete m_vocabulary;
+		m_vocabulary = nullptr;
+	}
 }
 
 void WordTestStudy::draw(int handX, int handY) const {
@@ -197,8 +210,7 @@ void WordTestStudy::draw(int handX, int handY) const {
 */
 SpeakingPractice::SpeakingPractice(Teacher* teacher_p) {
 	m_teacher_p = teacher_p;
-	m_speakingSets = new SpeakingSet("data/speaking/speaking.csv");
-	m_speakingSets->shuffle();
+	m_speakingSets = nullptr;
 	m_font = CreateFontToHandle(NULL, 40, 3);
 	m_sentenceFont = CreateFontToHandle(NULL, 30, 3);
 	m_repeatButton = new Button("‚à‚¤ˆê“x", 100, 750, 200, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
@@ -209,8 +221,10 @@ SpeakingPractice::SpeakingPractice(Teacher* teacher_p) {
 }
 
 SpeakingPractice::~SpeakingPractice() {
-	m_speakingSets->write();
-	delete m_speakingSets;
+	if (m_speakingSets != nullptr) {
+		m_speakingSets->write();
+		delete m_speakingSets;
+	}
 	DeleteFontToHandle(m_font);
 	DeleteFontToHandle(m_sentenceFont);
 	delete m_repeatButton;
@@ -250,13 +264,24 @@ bool SpeakingPractice::play(int handX, int handY, bool onlyImportant) {
 
 void SpeakingPractice::init(bool onlyImportant) {
 	m_nextButton->changeFlag(false, BLUE);
-	m_speakingSets->write();
+	if (m_speakingSets != nullptr) {
+		end();
+	}
+	m_speakingSets = new SpeakingSet("data/speaking/speaking.csv");
 	m_speakingSets->init();
 	m_speakingSets->shuffle();
 	if (onlyImportant) {
 		m_speakingSets->setFirstImportantSentence();
 	}
 	m_stopWatch->init();
+}
+
+void SpeakingPractice::end() {
+	if (m_speakingSets != nullptr) {
+		m_speakingSets->write();
+		delete m_speakingSets;
+		m_speakingSets = nullptr;
+	}
 }
 
 void SpeakingPractice::draw(int handX, int handY) const {

--- a/Study.h
+++ b/Study.h
@@ -74,6 +74,7 @@ public:
 
 	bool play(int handX, int handY, bool onlyImportant);
 	void init(bool onlyImportant);
+	void end();
 	void draw(int handX, int handY) const;
 };
 
@@ -103,6 +104,7 @@ public:
 
 	bool play(int handX, int handY, bool onlyImportant);
 	void init(bool onlyImportant);
+	void end();
 	void draw(int handX, int handY) const;
 };
 

--- a/Teacher.cpp
+++ b/Teacher.cpp
@@ -306,26 +306,22 @@ void Teacher::speaking(string sentence, int wait, EMOTE emote, bool animeRepeat)
 	m_text->setText(sentence);
 }
 
-// 
+// メニュー画面での雑談
 void Teacher::setRandomText() {
 	// セリフの総数
 	int sum = 5;
 	// レベルが上がるとセリフの数が増える
-	if (getLevel() < 10) {
-		sum = 5;
-	}
+	sum += getLevel();
 	int num = GetRand(sum - 1) + 1000;
 	setText(num, 120, EMOTE::NORMAL, true);
 }
 
-// 
+// 勉強中の発言
 void Teacher::setAdviceText() {
 	// セリフの総数
 	int sum = 5;
 	// レベルが上がるとセリフの数が増える
-	if (getLevel() < 10) {
-		sum = 5;
-	}
+	sum += getLevel();
 	int num = GetRand(sum - 1) + 2000;
 	setText(num, 120, EMOTE::NORMAL, true);
 }


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
1レベルごとに増える。

こまめにセリフを考えて追加する必要があるが、いったんこれで頑張ってみる。

また、ボキャブラやスピーキング文のcsvファイルがツール起動時に必ず開かれる仕様から、単語テストや音読練習時にのみ開かれる仕様に変更。

これによって、単語テスト中でなければツールを起動しながらボキャブラのcsvファイルを手元で編集してもおかしなことにならない。

# やったこと
記入欄

# 懸念点
記入欄