### PR TITLE
前の単語へ戻る機能を追加

### DIFF
--- a/Study.cpp
+++ b/Study.cpp
@@ -115,10 +115,12 @@ WordTestStudy::WordTestStudy(Teacher* teacher_p) {
 	m_teacher_p = teacher_p;
 	m_vocabulary = nullptr;
 	m_font = CreateFontToHandle(NULL, 40, 3);
+	m_miniFont = CreateFontToHandle(NULL, 30, 5);
 	m_answerButton = new Button("正解発表", 100, 750, 200, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
-	m_nextButton = new Button("次へ", 400, 750, 200, 100, BLUE, BLUE, m_font, BLACK);
-	m_importantButton = new Button("要注意", 700, 750, 200, 100, LIGHT_RED, RED, m_font, BLACK);
-	m_removeButton = new Button("削除", 1150, 750, 150, 100, GRAY, WHITE, m_font, BLACK);
+	m_nextButton = new Button("次へ", 320, 750, 200, 100, BLUE, BLUE, m_font, BLACK);
+	m_importantButton = new Button("要注意", 540, 750, 200, 100, LIGHT_RED, RED, m_font, BLACK);
+	m_prevButton = new Button("戻る", 760, 750, 150, 100, BLUE, BLUE, m_font, BLACK);
+	m_removeButton = new Button("長押しで削除", 1100, 750, 200, 100, GRAY, WHITE, m_miniFont, BLACK);
 	m_nextButton->changeFlag(false, BLUE);
 	m_stopWatch = new StopWatch();
 }
@@ -129,15 +131,26 @@ WordTestStudy::~WordTestStudy() {
 		delete m_vocabulary;
 	}
 	DeleteFontToHandle(m_font);
+	DeleteFontToHandle(m_miniFont);
 	delete m_answerButton;
 	delete m_nextButton;
 	delete m_importantButton;
+	delete m_prevButton;
 	delete m_removeButton;
 	delete m_stopWatch;
 }
 
 bool WordTestStudy::play(int handX, int handY, bool onlyImportant) {
+
 	m_stopWatch->count();
+
+	if (m_vocabulary->getIndex() == m_vocabulary->getPrevIndex()) {
+		m_prevButton->changeFlag(false, BLUE);
+	}
+	else {
+		m_prevButton->changeFlag(true, LIGHT_BLUE);
+	}
+
 	if (leftClick() == 1) {
 		if (m_answerButton->overlap(handX, handY)) {
 			m_nextButton->changeFlag(true, LIGHT_BLUE);
@@ -148,16 +161,24 @@ bool WordTestStudy::play(int handX, int handY, bool onlyImportant) {
 			m_nextButton->changeFlag(false, BLUE);
 			m_teacher_p->setText(1, 120, EMOTE::NORMAL, true);
 		}
+		if (m_prevButton->overlap(handX, handY)) {
+			m_vocabulary->goPrevWord();
+		}
 		if (m_importantButton->overlap(handX, handY)) {
 			m_vocabulary->setImportantFlag(!m_vocabulary->getWord().importantFlag);
 			if (m_vocabulary->getWord().importantFlag){ m_teacher_p->setText(3, 120, EMOTE::ANGRY, true); }
 			else{ m_teacher_p->setText(4, 120, EMOTE::SMILE, true); }
 		}
+	}
+
+	if (leftClick() == 60) {
 		if (m_removeButton->overlap(handX, handY)) {
 			m_vocabulary->removeWord();
 		}
 	}
+
 	return false;
+
 }
 
 void WordTestStudy::init(bool onlyImportant) {
@@ -198,6 +219,7 @@ void WordTestStudy::draw(int handX, int handY) const {
 	m_answerButton->draw(handX, handY);
 	m_importantButton->draw(handX, handY);
 	m_nextButton->draw(handX, handY);
+	m_prevButton->draw(handX, handY);
 	m_removeButton->draw(handX, handY);
 	ostringstream oss;
 	oss << "総単語数：" << m_vocabulary->getIndex() + 1 << "/" << m_vocabulary->getWordSum() << ", 要注意単語：" << m_vocabulary->getImportantWordSum() << "個";

--- a/Study.h
+++ b/Study.h
@@ -58,10 +58,12 @@ private:
 	Vocabulary* m_vocabulary;
 
 	int m_font;
+	int m_miniFont;
 
 	Button* m_answerButton;
 	Button* m_importantButton;
 	Button* m_nextButton;
+	Button* m_prevButton;
 	Button* m_removeButton;
 
 	Teacher* m_teacher_p;

--- a/Vocabulary.cpp
+++ b/Vocabulary.cpp
@@ -13,6 +13,7 @@ using namespace std;
 Vocabulary::Vocabulary(const char* path) {
 	m_path = path;
 	m_index = 0;
+	m_prevIndex = m_index;
 	m_importantWordSum = 0;
 	read();
 }
@@ -97,6 +98,7 @@ void Vocabulary::removeWord() {
 	m_words[m_index] = m_words.back();
 	m_words.pop_back();
 	if (m_index >= (int)m_words.size()) { m_index = (int)m_words.size() - 1; }
+	m_prevIndex = m_index;
 }
 
 // —v’ˆÓ
@@ -124,6 +126,7 @@ Word Vocabulary::getWord() {
 
 // Ÿ‚Ì’PŒê‚ÖˆÚ“®
 void Vocabulary::goNextWord(bool onlyImportant) {
+	m_prevIndex = m_index;
 	unsigned int i = 0;
 	while (i == 0 || (onlyImportant && !m_words[m_index].importantFlag && i < m_words.size())) {
 		if (++m_index == (int)m_words.size()) {
@@ -133,8 +136,13 @@ void Vocabulary::goNextWord(bool onlyImportant) {
 	}
 }
 
+void Vocabulary::goPrevWord() {
+	m_index = m_prevIndex;
+}
+
 void Vocabulary::init() {
 	m_index = 0;
+	m_prevIndex = m_index;
 	m_importantWordSum = 0;
 	read();
 }

--- a/Vocabulary.h
+++ b/Vocabulary.h
@@ -20,6 +20,8 @@ private:
 
 	int m_index;
 
+	int m_prevIndex;
+
 	int m_importantWordSum;
 
 public:
@@ -28,6 +30,7 @@ public:
 
 	// ƒQƒbƒ^
 	inline int getIndex() const { return m_index; }
+	inline int getPrevIndex() const { return m_prevIndex; }
 	inline int getWordSum() const { return (int)m_words.size(); }
 	inline int getImportantWordSum() const { return m_importantWordSum; }
 
@@ -43,6 +46,7 @@ public:
 	void shuffle();
 	Word getWord();
 	void goNextWord(bool onlyImportant);
+	void goPrevWord();
 	void init();
 	void setFirstImportantWord();
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
ボタンを押下し1つ前の単語に戻れる。

背景：間違えて重要語のON/OFFを変えてしまったと気付いて戻りたいことがしばしばあった。

仕様：
- 2つ前までは戻れない。
- 重要語のみのテスト中、重要語から外した単語へ戻ることも可能。
- 音読練習では現状必要性を感じないので追加しない。

# やったこと
記入欄

# 懸念点
記入欄