### PR TITLE
英文隠し機能を追加

### DIFF
--- a/Study.h
+++ b/Study.h
@@ -92,8 +92,18 @@ private:
 	int m_font;
 	int m_sentenceFont;
 
+	enum HIDE_STATE {
+		NO_HIDE,
+		EN_HIDE,
+		EN_HINT_HIDE
+	};
+
+	// 0:ëSï\é¶ 1:âpï∂âBÇµ 2:âpï∂Å{ÉqÉìÉgâBÇµ
+	HIDE_STATE m_hideState;
+
 	Button* m_repeatButton;
 	Button* m_importantButton;
+	Button* m_answerButton;
 	Button* m_nextButton;
 
 	Teacher* m_teacher_p;


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
音読練習モードで英文を隠し、英作文の練習もできるようにする。

何も隠さない（デフォルト）、英文隠し、英文＋ヒント隠し、をボタンを押して切り替える。

# やったこと
記入欄

# 懸念点
記入欄