### PR TITLE
重要文のみの音読練習レッスンを追加＆朝・夜の振り返りを統合

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -159,10 +159,10 @@ bool Stats::read() {
 	fread(&m_breakTimeCnt, sizeof(m_breakTimeCnt), 1, intFp);
 	fread(&m_freeStudyCnt, sizeof(m_freeStudyCnt), 1, intFp);
 	fread(&m_longTextStudyCnt, sizeof(m_longTextStudyCnt), 1, intFp);
-	fread(&m_morningReviewCnt, sizeof(m_morningReviewCnt), 1, intFp);
+	fread(&m_reviewCnt, sizeof(m_reviewCnt), 1, intFp);
 	fread(&m_radioCnt, sizeof(m_radioCnt), 1, intFp);
 	fread(&m_speakingStudyCnt, sizeof(m_speakingStudyCnt), 1, intFp);
-	fread(&m_eveningReviewCnt, sizeof(m_eveningReviewCnt), 1, intFp);
+	fread(&m_onlyImportantSpeakingStudyCnt, sizeof(m_onlyImportantSpeakingStudyCnt), 1, intFp);
 	fclose(intFp);
 	return true;
 }
@@ -181,10 +181,10 @@ bool Stats::write() {
 	fwrite(&m_breakTimeCnt, sizeof(m_breakTimeCnt), 1, intFp);
 	fwrite(&m_freeStudyCnt, sizeof(m_freeStudyCnt), 1, intFp);
 	fwrite(&m_longTextStudyCnt, sizeof(m_longTextStudyCnt), 1, intFp);
-	fwrite(&m_morningReviewCnt, sizeof(m_morningReviewCnt), 1, intFp);
+	fwrite(&m_reviewCnt, sizeof(m_reviewCnt), 1, intFp);
 	fwrite(&m_radioCnt, sizeof(m_radioCnt), 1, intFp);
 	fwrite(&m_speakingStudyCnt, sizeof(m_speakingStudyCnt), 1, intFp);
-	fwrite(&m_eveningReviewCnt, sizeof(m_eveningReviewCnt), 1, intFp);
+	fwrite(&m_onlyImportantSpeakingStudyCnt, sizeof(m_onlyImportantSpeakingStudyCnt), 1, intFp);
 	fclose(intFp);
 	return true;
 }

--- a/Game.h
+++ b/Game.h
@@ -91,10 +91,10 @@ private:
 	long long int m_breakTimeCnt;
 	long long int m_freeStudyCnt;
 	long long int m_longTextStudyCnt;
-	long long int m_morningReviewCnt;
+	long long int m_reviewCnt;
 	long long int m_radioCnt;
 	long long int m_speakingStudyCnt;
-	long long int m_eveningReviewCnt;
+	long long int m_onlyImportantSpeakingStudyCnt;
 
 public:
 
@@ -123,14 +123,14 @@ public:
 	inline void setFreeStudyCnt(long long int cnt) { m_freeStudyCnt = cnt; }
 	inline long long int getLongTextStudyCnt() const { return m_longTextStudyCnt; }
 	inline void setLongTextStudyCnt(long long int cnt) { m_longTextStudyCnt = cnt; }
-	inline long long int getMorningReviewCnt() const { return m_morningReviewCnt; }
-	inline void setMorningReviewCnt(long long int cnt) { m_morningReviewCnt = cnt; }
+	inline long long int getReviewCnt() const { return m_reviewCnt; }
+	inline void setReviewCnt(long long int cnt) { m_reviewCnt = cnt; }
 	inline long long int getRadioCnt() const { return m_radioCnt; }
 	inline void setRadioCnt(long long int cnt) { m_radioCnt = cnt; }
 	inline long long int getSpeakingStudyCnt() const { return m_speakingStudyCnt; }
 	inline void setSpeakingStudyCnt(long long int cnt) { m_speakingStudyCnt = cnt; }
-	inline long long int getEveningReviewCnt() const { return m_eveningReviewCnt; }
-	inline void setEveningReviewCnt(long long int cnt) { m_eveningReviewCnt = cnt; }
+	inline long long int getOnlyImportantSpeakingStudyCnt() const { return m_onlyImportantSpeakingStudyCnt; }
+	inline void setOnlyImportantSpeakingStudyCnt(long long int cnt) { m_onlyImportantSpeakingStudyCnt = cnt; }
 };
 
 

--- a/Lesson.cpp
+++ b/Lesson.cpp
@@ -35,10 +35,10 @@ Lesson::Lesson(int font, Teacher* teacher_p, Stats* stats_p, Stats* dailyStats_p
 	m_breakTimeButton = new Button("‹xŒe", 900, 450, 350, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
 	m_freeStudyButton = new Button("Ž©K", 100, 600, 350, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
 	m_longTextStudyButton = new Button("’·•¶–â‘è", 500, 600, 350, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
-	m_morningReviewButton = new Button("’©‚ÌU‚è•Ô‚è", 900, 600, 350, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
+	m_morningReviewButton = new Button("U‚è•Ô‚è", 900, 600, 350, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
 	m_radioButton = new Button("ƒ‰ƒWƒI‰p‰ï˜b", 100, 750, 350, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
 	m_speakingStudyButton = new Button("‰¹“Ç—ûK", 500, 750, 350, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
-	m_eveningReviewButton = new Button("–é‚ÌU‚è•Ô‚è", 900, 750, 350, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
+	m_onlyImportantSpeakingStudyButton = new Button("d—v•¶‚Ì‚Ý‰¹“Ç", 900, 750, 350, 100, LIGHT_BLUE, BLUE, m_font, BLACK);
 
 }
 
@@ -58,7 +58,7 @@ Lesson::~Lesson() {
 	delete m_morningReviewButton;
 	delete m_radioButton;
 	delete m_speakingStudyButton;
-	delete m_eveningReviewButton;
+	delete m_onlyImportantSpeakingStudyButton;
 }
 
 bool Lesson::play(int handX, int handY, int mouseWheel) {
@@ -93,7 +93,7 @@ bool Lesson::play(int handX, int handY, int mouseWheel) {
 					m_state = LESSON_NAME::LONG_TEXT_STUDY;
 				}
 				else if (m_morningReviewButton->overlap(handX, handY)) {
-					m_state = LESSON_NAME::MORNING_REVIEW;
+					m_state = LESSON_NAME::REVIEW;
 				}
 				else if (m_radioButton->overlap(handX, handY)) {
 					m_state = LESSON_NAME::RADIO;
@@ -102,8 +102,9 @@ bool Lesson::play(int handX, int handY, int mouseWheel) {
 					m_speakingPractice->init(false);
 					m_state = LESSON_NAME::SPEAKING_STUDY;
 				}
-				else if (m_eveningReviewButton->overlap(handX, handY)) {
-					m_state = LESSON_NAME::EVENING_REVIEW;
+				else if (m_onlyImportantSpeakingStudyButton->overlap(handX, handY)) {
+					m_speakingPractice->init(true);
+					m_state = LESSON_NAME::SPEAKING_STUDY_IMPORTANT;
 				}
 			}
 			// ƒŒƒbƒXƒ“ŠJŽn
@@ -145,9 +146,9 @@ bool Lesson::play(int handX, int handY, int mouseWheel) {
 			m_stats_p->setLongTextStudyCnt(m_stats_p->getLongTextStudyCnt() + 1);
 			m_dailyStats_p->setLongTextStudyCnt(m_dailyStats_p->getLongTextStudyCnt() + 1);
 			break;
-		case MORNING_REVIEW:		// ’©‚ÌU‚è•Ô‚è
-			m_stats_p->setMorningReviewCnt(m_stats_p->getMorningReviewCnt() + 1);
-			m_dailyStats_p->setMorningReviewCnt(m_dailyStats_p->getMorningReviewCnt() + 1);
+		case REVIEW:		// U‚è•Ô‚è
+			m_stats_p->setReviewCnt(m_stats_p->getReviewCnt() + 1);
+			m_dailyStats_p->setReviewCnt(m_dailyStats_p->getReviewCnt() + 1);
 			break;
 		case RADIO:					// ƒ‰ƒWƒI‰p‰ï˜b
 			m_stats_p->setRadioCnt(m_stats_p->getRadioCnt() + 1);
@@ -158,9 +159,10 @@ bool Lesson::play(int handX, int handY, int mouseWheel) {
 			m_stats_p->setSpeakingStudyCnt(m_stats_p->getSpeakingStudyCnt() + 1);
 			m_dailyStats_p->setSpeakingStudyCnt(m_dailyStats_p->getSpeakingStudyCnt() + 1);
 			break;
-		case EVENING_REVIEW:		// –é‚ÌU‚è•Ô‚è
-			m_stats_p->setEveningReviewCnt(m_stats_p->getEveningReviewCnt() + 1);
-			m_dailyStats_p->setEveningReviewCnt(m_dailyStats_p->getEveningReviewCnt() + 1);
+		case SPEAKING_STUDY_IMPORTANT:		// d—v•¶‰¹“Ç
+			m_speakingPractice->play(handX, handY, mouseWheel, true);
+			m_stats_p->setOnlyImportantSpeakingStudyCnt(m_stats_p->getOnlyImportantSpeakingStudyCnt() + 1);
+			m_dailyStats_p->setOnlyImportantSpeakingStudyCnt(m_dailyStats_p->getOnlyImportantSpeakingStudyCnt() + 1);
 			break;
 	}
 	if (m_state != LESSON_NAME::SELECT_LESSON) {
@@ -196,10 +198,10 @@ void Lesson::draw(int handX, int handY) const {
 		DrawFormatString(900, 430, WHITE, (dateName + getTimeString(stats->getBreakTimeCnt())).c_str());
 		DrawFormatString(100, 580, WHITE, (dateName + getTimeString(stats->getFreeStudyCnt())).c_str());
 		DrawFormatString(500, 580, WHITE, (dateName + getTimeString(stats->getLongTextStudyCnt())).c_str());
-		DrawFormatString(900, 580, WHITE, (dateName + getTimeString(stats->getMorningReviewCnt())).c_str());
+		DrawFormatString(900, 580, WHITE, (dateName + getTimeString(stats->getReviewCnt())).c_str());
 		DrawFormatString(100, 730, WHITE, (dateName + getTimeString(stats->getRadioCnt())).c_str());
 		DrawFormatString(500, 730, WHITE, (dateName + getTimeString(stats->getSpeakingStudyCnt())).c_str());
-		DrawFormatString(900, 730, WHITE, (dateName + getTimeString(stats->getEveningReviewCnt())).c_str());
+		DrawFormatString(900, 730, WHITE, (dateName + getTimeString(stats->getOnlyImportantSpeakingStudyCnt())).c_str());
 		m_wordTestButton->draw(handX, handY);
 		m_onlyImportantTestButton->draw(handX, handY);
 		m_diaryButton->draw(handX, handY);
@@ -211,7 +213,7 @@ void Lesson::draw(int handX, int handY) const {
 		m_morningReviewButton->draw(handX, handY);
 		m_radioButton->draw(handX, handY);
 		m_speakingStudyButton->draw(handX, handY);
-		m_eveningReviewButton->draw(handX, handY);
+		m_onlyImportantSpeakingStudyButton->draw(handX, handY);
 		break;
 	case WORD_TEST:				// ’PŒêƒeƒXƒg
 		lessonName = "‘S’PŒêƒeƒXƒg‚ÌŽžŠÔ 15m";
@@ -239,24 +241,26 @@ void Lesson::draw(int handX, int handY) const {
 	case LONG_TEXT_STUDY:		// ’·•¶–â‘è
 		lessonName = "’·•¶–â‘è‚Å•×‹­‚·‚éŽžŠÔ 15m";
 		break;
-	case MORNING_REVIEW:		// ’©‚ÌU‚è•Ô‚è
-		lessonName = "’©‚ÌU‚è•Ô‚è 10m";
+	case REVIEW:		// U‚è•Ô‚è
+		lessonName = "U‚è•Ô‚è ’©10m –é20m";
 		break;
 	case RADIO:					// ƒ‰ƒWƒI‰p‰ï˜b
 		lessonName = "ƒ‰ƒWƒI‰p‰ï˜b‚ÌŽžŠÔ 20m";
 		break;
 	case SPEAKING_STUDY:		// ‰¹“Ç—ûK
 		m_speakingPractice->draw(handX, handY);
-		lessonName = "‰¹“Ç—ûK‹­‚ÌŽžŠÔ 20m";
+		lessonName = "‰¹“Ç—ûK‚ÌŽžŠÔ 20m";
 		break;
-	case EVENING_REVIEW:		// –é‚ÌU‚è•Ô‚è
-		lessonName = "–é‚ÌU‚è•Ô‚è‚ÌŽžŠÔ 20m";
+	case SPEAKING_STUDY_IMPORTANT:		// d—v•¶‰¹“Ç
+		m_speakingPractice->draw(handX, handY);
+		lessonName = "d—v•¶‰¹“Ç‚ÌŽžŠÔ 20m";
 		break;
 	}
 	DrawStringToHandle(100, 250, lessonName.c_str(), WHITE, m_font);
 	if (m_state != LESSON_NAME::SELECT_LESSON
 		&& m_state != LESSON_NAME::WORD_TEST && m_state != LESSON_NAME::WORD_TEST_IMPORTANT
-		&& m_state != LESSON_NAME::SPEAKING_STUDY) {
+		&& m_state != LESSON_NAME::SPEAKING_STUDY
+		&& m_state != LESSON_NAME::SPEAKING_STUDY_IMPORTANT) {
 		DrawStringToHandle(550, 550, getTimeString(m_stopWatch->getCnt()).c_str(), WHITE, m_font);
 	}
 }

--- a/Lesson.h
+++ b/Lesson.h
@@ -9,19 +9,19 @@ class WordTestStudy;
 class SpeakingPractice;
 
 enum LESSON_NAME {
-	SELECT_LESSON,			// レッスン選択画面
-	WORD_TEST,				// 単語テスト
-	WORD_TEST_IMPORTANT,	// 重要語テスト
-	DIARY,					// 日記
-	RADIO_REVIEW,			// ラジオ英会話復習
-	GRAMMAR_STUDY,			// 文法
-	BREAK_TIME,				// 休憩
-	FREE_STUDY,				// 自習
-	LONG_TEXT_STUDY,		// 長文問題
-	MORNING_REVIEW,			// 朝の振り返り
-	RADIO,					// ラジオ英会話
-	SPEAKING_STUDY,			// 音読練習
-	EVENING_REVIEW			// 夜の振り返り
+	SELECT_LESSON,				// レッスン選択画面
+	WORD_TEST,					// 単語テスト
+	WORD_TEST_IMPORTANT,		// 重要語テスト
+	DIARY,						// 日記
+	RADIO_REVIEW,				// ラジオ英会話復習
+	GRAMMAR_STUDY,				// 文法
+	BREAK_TIME,					// 休憩
+	FREE_STUDY,					// 自習
+	LONG_TEXT_STUDY,			// 長文問題
+	REVIEW,						// 振り返り
+	RADIO,						// ラジオ英会話
+	SPEAKING_STUDY,				// 音読練習
+	SPEAKING_STUDY_IMPORTANT,	// 重要文音読
 };
 
 class Lesson {
@@ -46,7 +46,7 @@ private:
 	Button* m_morningReviewButton;
 	Button* m_radioButton;
 	Button* m_speakingStudyButton;
-	Button* m_eveningReviewButton;
+	Button* m_onlyImportantSpeakingStudyButton;
 
 	int m_font;
 

--- a/Study.cpp
+++ b/Study.cpp
@@ -80,7 +80,7 @@ bool Study::play(int handX, int handY, int mouseWheel) {
 				m_speakingPractiace->init(false);
 			}
 			else if (m_onlyImportantspeakingPracticeButton->overlap(handX, handY)) {
-				m_state = STUDY_MODE::SPEAKING_PRACTICE;
+				m_state = STUDY_MODE::SPEAKING_PRACTICE_IMPORTANT;
 				m_speakingPractiace->init(true);
 			}
 		}


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
「重要文のみの音読練習」をレッスンに追加。

それに伴い画面サイズの都合上レッスン数を１つ減らす必要があり、朝と夜の振り返りを１つに統合し「振り返り」レッスンにした。

また、自習モードでバグがあり重要文のみ音読練習をやっても重要文以外も出題されてしまっていたので修正。

# やったこと
記入欄

# 懸念点
記入欄